### PR TITLE
Update slurm-ops-manager in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ops==2.*
 distro
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.15
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.16


### PR DESCRIPTION
## Description

Update the `slurm-ops-manager` to version 0.8.16 in the `requirements.txt` file to apply the changes to install Slurm 23.02 by default.

Obs.: This PR can only be merged after https://github.com/omnivector-solutions/slurm-ops-manager/pull/98 is merged and the release 0.8.16 is created for `slurm-ops-manager`.

## How was the code tested?

The code was tested locally and via the CI/CD workflow.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [ ] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.