### PR TITLE
fix: prime NHC tarball within charm during packing

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -34,12 +34,16 @@ bases:
         architectures: [amd64]
 
 parts:
-  charm:
+  charm: {}
+  nhc:
+    plugin: nil
     build-packages:
       - wget
+    override-pull: |
+      wget https://github.com/mej/nhc/releases/download/1.4.3/lbnl-nhc-1.4.3.tar.gz
     override-build: |
-       wget https://github.com/mej/nhc/releases/download/1.4.3/lbnl-nhc-1.4.3.tar.gz
-       craftctl default
+      install -m644 -D -t $CRAFT_PART_INSTALL lbnl-nhc-1.4.3.tar.gz
+      craftctl default
 
 provides:
   slurmctld:

--- a/src/slurmd_ops.py
+++ b/src/slurmd_ops.py
@@ -173,7 +173,12 @@ class SlurmdManager:
         base_path.mkdir()
 
         cmd = f"tar --extract --directory {base_path} --file lbnl-nhc-1.4.3.tar.gz".split()
-        subprocess.run(cmd)
+        try:
+            result = subprocess.check_output(cmd, stderr=subprocess.STDOUT, text=True)
+            logger.debug(result)
+        except subprocess.CalledProcessError as e:
+            logger.error("failed to extract NHC using tar. reason:\n%s", e.stdout)
+            return False
 
         full_path = base_path / os.listdir(base_path)[0]
 


### PR DESCRIPTION
## Description

This pull request properly primes the NHC tarball within the slurmd operator so that the operator will deploy correctly. It ensures that the NHC tarball is placed in `$CRAFT_PART_INSTALL` so that it is eventually copied into the file artifact produced by `charmcraft pack`.

cc @jedel1043 helped with putting the initial patch together. After much boil and toil with discrepancies between our machines, we discovered that we needed to add `charm: {}` to the parts definition in _charmcraft.yaml_  to ensure that the charm would pack correctly. If we just specified NHC, only NHC would be put into the final charm, none of the magic charm sauce :scream:  

## How was the code tested?

Ran tests locally on my Ubuntu 24.04 workstation. Ensured that NHC was properly built during install hook execution.

## Related issues and/or tasks

Fixes #36 

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
