### PR TITLE
chore: fix CI pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        bases:          
+        bases:
           - ubuntu@22.04
     name: Integration tests (LXD) | ${{ matrix.bases }}
     runs-on: ubuntu-latest
@@ -79,10 +79,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          path: main
+      - name: Fetch slurmctld
+        uses: actions/checkout@v4
+        with:
+          repository: charmed-hpc/slurmctld-operator
+          path: slurmctld-operator
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
           juju-channel: 3.1/stable
       - name: Run tests
-        run: tox run -e integration -- --charm-base=${{ matrix.bases }}
+        run: cd main && tox run -e integration -- --charm-base=${{ matrix.bases }} --use-local

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,12 +65,16 @@ jobs:
 
   integration-test:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         bases:
           - ubuntu@22.04
-    name: Integration tests (LXD) | ${{ matrix.bases }}
+        local: [true, false]
+    name: Integration tests (LXD) ${{ matrix.local && '|' || '| Charmhub (edge) |'}} ${{ matrix.bases }}
     runs-on: ubuntu-latest
+    # Testing against Charmhub will probably yield errors when doing breaking changes, so don't
+    # block CI on that.
+    continue-on-error: ${{ !matrix.local }}
     needs:
       - inclusive-naming-check
       - lint
@@ -83,6 +87,7 @@ jobs:
           path: main
       - name: Fetch slurmctld
         uses: actions/checkout@v4
+        if: ${{ matrix.local }}
         with:
           repository: charmed-hpc/slurmctld-operator
           path: slurmctld-operator
@@ -92,4 +97,7 @@ jobs:
           provider: lxd
           juju-channel: 3.1/stable
       - name: Run tests
-        run: cd main && tox run -e integration -- --charm-base=${{ matrix.bases }} --use-local
+        run: |
+          cd main && tox run -e integration -- \
+             --charm-base=${{ matrix.bases }} \
+             ${{ matrix.local && '--use-local' || '' }}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -73,23 +73,3 @@ async def slurmctld_charm(request, ops_test: OpsTest) -> Union[str, Path]:
             )
 
     return "slurmctld"
-
-
-@pytest.fixture(scope="module")
-async def slurmdbd_charm(request, ops_test: OpsTest) -> Union[str, Path]:
-    """Pack slurmdbd charm to use for integration tests when --use-local is specified.
-
-    Returns:
-        `str` "slurmdbd" if --use-local not specified or if SLURMDBD_DIR does not exist.
-    """
-    if request.config.option.use_local:
-        logger.info("Using local slurmdbd operator rather than pulling from Charmhub")
-        if SLURMDBD_DIR.exists():
-            return await ops_test.build_charm(SLURMDBD_DIR)
-        else:
-            logger.warning(
-                f"{SLURMDBD_DIR} not found. "
-                f"Defaulting to latest/edge slurmdbd operator from Charmhub"
-            )
-
-    return "slurmdbd"

--- a/tox.ini
+++ b/tox.ini
@@ -78,5 +78,5 @@ commands =
         -s \
         --tb native \
         --log-cli-level=INFO \
-        {[vars]tst_path}integration \
+        {[vars]tst_path}/integration \
         {posargs}


### PR DESCRIPTION
This will always pull from `main` when testing against `slurmctld-operator`, which is arguably better when trying to do breaking changes in integrations between the charms.

## How was the code tested?

Locally using a development environment based on Ubuntu Jammy.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
