### PR TITLE
ci: bump charming-actions to 2.5.0-rc

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,10 +32,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.2.0
+        uses: canonical/charming-actions/channel@2.5.0-rc
         id: channel
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.2.0
+        uses: canonical/charming-actions/upload-charm@2.5.0-rc
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Description

This version bump fixes the CI release job, because 2.5.0 added support for the unified charmcraft.yaml file.

## How was the code tested?

N/A, this can only be tested by the CI.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
