### PR TITLE
chore: enable CI for the experimental branch

### DIFF
--- a/.github/workflows/experimental.yaml
+++ b/.github/workflows/experimental.yaml
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: slurmd charm tests
+name: slurmd charm tests (experimental)
 on:
   workflow_call:
   pull_request:
     branches:
-      - main
+      - experimental
 
 jobs:
   inclusive-naming-check:
@@ -67,16 +67,12 @@ jobs:
 
   integration-test:
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         bases:
           - ubuntu@22.04
-        local: [true, false]
-    name: Integration tests (LXD) ${{ matrix.local && '|' || '| Charmhub (edge) |'}} ${{ matrix.bases }}
+    name: Integration tests (LXD) | ${{ matrix.bases }}
     runs-on: ubuntu-latest
-    # Testing against Charmhub will probably yield errors when doing breaking changes, so don't
-    # block CI on that.
-    continue-on-error: ${{ !matrix.local }}
     needs:
       - inclusive-naming-check
       - lint
@@ -89,10 +85,10 @@ jobs:
           path: main
       - name: Fetch slurmctld
         uses: actions/checkout@v4
-        if: ${{ matrix.local }}
         with:
           repository: charmed-hpc/slurmctld-operator
           path: slurmctld-operator
+          ref: experimental
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -102,4 +98,4 @@ jobs:
         run: |
           cd main && tox run -e integration -- \
              --charm-base=${{ matrix.bases }} \
-             ${{ matrix.local && '--use-local' || '' }}
+             --use-local

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -71,7 +71,7 @@ async def test_munge_is_active(ops_test: OpsTest):
     """Test that munge is active."""
     logger.info("Checking that munge is active inside Juju unit")
     slurmd_unit = ops_test.model.units.get(UNIT_NAME)
-    cmd_res = (await slurmd_unit.ssh(command="systemctl is-active munge")).strip("\n")
+    cmd_res = (await slurmd_unit.ssh(command="systemctl is-active snap.slurm.munged")).strip("\n")
     assert cmd_res == "active"
 
 
@@ -81,5 +81,5 @@ async def test_slurmd_is_active(ops_test: OpsTest):
     """Test that slurmd is active."""
     logger.info("Checking that slurmd is active inside Juju unit")
     slurmd_unit = ops_test.model.units.get(UNIT_NAME)
-    cmd_res = (await slurmd_unit.ssh(command="systemctl is-active slurmd")).strip("\n")
+    cmd_res = (await slurmd_unit.ssh(command="systemctl is-active snap.slurm.slurmd")).strip("\n")
     assert cmd_res == "active"


### PR DESCRIPTION
## Description

Since the experimental branch and the main branch use different versions of SLURM, we need to use the experimental branch for `slurmctld` when pushing new changes to `slurmd`.

## How was the code tested?

N/A. Tested when running CI.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.