### PR TITLE
chore: bump systemd notices

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -60,7 +60,7 @@ class SlurmdCharm(CharmBase):
 
         self._slurmd_manager = SlurmdManager()
         self._slurmctld = Slurmctld(self, "slurmctld")
-        self._systemd_notices = SystemdNotices(self, Service("snap.slurm.slurmd", "slurmd"))
+        self._systemd_notices = SystemdNotices(self, [Service("snap.slurm.slurmd", "slurmd")])
 
         event_handler_bindings = {
             self.on.install: self._on_install,


### PR DESCRIPTION
## Description

Bumps the `juju_systemd_notices` library to its latest version, removing the custom version
we had before.

## How was the code tested?

Unit tests locally on an Ubuntu Jammy development machine.
Integration tests cannot be run until we integrate the snap onto `slurmdbd`.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
